### PR TITLE
Integración del Pago de Merch con MP

### DIFF
--- a/ProgressusWebApi/Controllers/MembresiaControllers/AAMercadoPagoController.cs
+++ b/ProgressusWebApi/Controllers/MembresiaControllers/AAMercadoPagoController.cs
@@ -127,7 +127,7 @@ namespace ProgressusWebApi.Controllers.MembresiaControllers
 
                 var paymentId = req!.data!.id;
 
-                var estado = "approved";// await _mercadoPagoService.ConsultarEstadoPreferencia(paymentId);
+                var estado = "approved";//await _mercadoPagoService.ConsultarEstadoPreferencia(paymentId);
                                 
                 if (estado == "approved")
                 {

--- a/ProgressusWebApi/Controllers/MembresiaControllers/AAMercadoPagoController.cs
+++ b/ProgressusWebApi/Controllers/MembresiaControllers/AAMercadoPagoController.cs
@@ -14,8 +14,10 @@ using ProgressusWebApi.Models.MembresiaModels;
 using ProgressusWebApi.Services.AuthServices.Interfaces;
 using ProgressusWebApi.Services.InventarioServices.Interfaces;
 using ProgressusWebApi.Services.MembresiaServices.Interfaces;
+using ProgressusWebApi.Services.PedidosServices.Interfaces;
 using System.Net.Http;
 using System.Text.Json;
+using WebApiMercadoPago.Services.Interface;
 
 namespace ProgressusWebApi.Controllers.MembresiaControllers
 {
@@ -28,13 +30,18 @@ namespace ProgressusWebApi.Controllers.MembresiaControllers
         private readonly ISolicitudDePagoService _solicituDePagoService;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IInventarioService _inventarioService;
+        private readonly IMercadoPagoService _mercadoPagoService;
+        private readonly IPedidoService _pedidoService;
 
-        public AAMercadoPagoController(IHttpClientFactory httpClientFactory, ISolicitudDePagoService solicitudDePagoService, UserManager<IdentityUser> userManager, IInventarioService inventarioService)
+        public AAMercadoPagoController(IHttpClientFactory httpClientFactory, ISolicitudDePagoService solicitudDePagoService, UserManager<IdentityUser> userManager, IInventarioService inventarioService
+            , IMercadoPagoService mp, IPedidoService pedido)
         {
             _httpClientFactory = httpClientFactory;
             _solicituDePagoService = solicitudDePagoService;
             _userManager = userManager;
             _inventarioService = inventarioService;
+            _mercadoPagoService = mp;
+            _pedidoService = pedido;
 
         }
 
@@ -108,6 +115,41 @@ namespace ProgressusWebApi.Controllers.MembresiaControllers
                 return StatusCode(500, "Error interno del servidor.");
             }
         }
-    
+
+        
+        [HttpPost("NotificarPedidoCompletado/{pedidoId}")]
+        public async Task<IActionResult> NotificarPedidoCompletado([FromBody] NotificationDto req, string pedidoId)
+        {
+            try
+            {
+                if(req == null || string.IsNullOrEmpty(pedidoId) || req.data?.id == null)
+                    return BadRequest();
+
+                var paymentId = req!.data!.id;
+
+                var estado = "approved";// await _mercadoPagoService.ConsultarEstadoPreferencia(paymentId);
+                                
+                if (estado == "approved")
+                {
+                    var registradoOK = await _pedidoService.RegistrarPago(pedidoId);
+                    if(!registradoOK)
+                        return BadRequest();
+
+                    return Ok();
+                }
+                else
+                {
+                    Console.WriteLine($"Error en la solicitud: {estado}");
+                    return BadRequest() ;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error: {ex.Message}");
+                return StatusCode(500, "Error interno del servidor.");
+            }
+        }
+
+
     }
 }

--- a/ProgressusWebApi/Controllers/MembresiaControllers/AAMercadoPagoController.cs
+++ b/ProgressusWebApi/Controllers/MembresiaControllers/AAMercadoPagoController.cs
@@ -127,7 +127,7 @@ namespace ProgressusWebApi.Controllers.MembresiaControllers
 
                 var paymentId = req!.data!.id;
 
-                var estado = "approved";//await _mercadoPagoService.ConsultarEstadoPreferencia(paymentId);
+                var estado = await _mercadoPagoService.ConsultarEstadoPreferencia(paymentId);
                                 
                 if (estado == "approved")
                 {

--- a/ProgressusWebApi/Controllers/MembresiaControllers/AAMercadoPagoController.cs
+++ b/ProgressusWebApi/Controllers/MembresiaControllers/AAMercadoPagoController.cs
@@ -140,7 +140,7 @@ namespace ProgressusWebApi.Controllers.MembresiaControllers
                 else
                 {
                     Console.WriteLine($"Error en la solicitud: {estado}");
-                    return BadRequest() ;
+                    return Ok();
                 }
             }
             catch (Exception ex)

--- a/ProgressusWebApi/Controllers/MerchControllers/CarritoController.cs
+++ b/ProgressusWebApi/Controllers/MerchControllers/CarritoController.cs
@@ -4,45 +4,45 @@ using ProgressusWebApi.Services.CarritoServices;
 
 namespace ProgressusWebApi.Controllers.MerchControllers
 {
-   
-        [Route("api/[controller]")]
-        [ApiController]
-        public class CarritoController : ControllerBase
+
+    [Route("api/[controller]")]
+    [ApiController]
+    public class CarritoController : ControllerBase
+    {
+        private readonly ICarritoService _carritoService;
+
+        public CarritoController(ICarritoService carritoService)
         {
-            private readonly ICarritoService _carritoService;
+            _carritoService = carritoService;
+        }
 
-            public CarritoController(ICarritoService carritoService)
-            {
-                _carritoService = carritoService;
-            }
+        [HttpGet("ObtenerCarrito/{usuarioId}")]
+        public async Task<IActionResult> ObtenerCarrito(string usuarioId)
+        {
+            var carrito = await _carritoService.ObtenerCarritoAsync(usuarioId);
+            return Ok(carrito);
+        }
 
-            [HttpGet("ObtenerCarrito/{usuarioId}")]
-            public async Task<IActionResult> ObtenerCarrito(string usuarioId)
-            {
-                var carrito = await _carritoService.ObtenerCarritoAsync(usuarioId);
-                return Ok(carrito);
-            }
+        [HttpPost("AgregarItem/{usuarioId}")]
+        public async Task<IActionResult> AgregarItem(string usuarioId, [FromBody] CarritoItem item)
+        {
+            await _carritoService.AgregarItemAlCarritoAsync(usuarioId, item);
+            return Ok();
+        }
 
-            [HttpPost("AgregarItem/{usuarioId}")]
-            public async Task<IActionResult> AgregarItem(string usuarioId, [FromBody] CarritoItem item)
-            {
-                await _carritoService.AgregarItemAlCarritoAsync(usuarioId, item);
-                return Ok();
-            }
+        [HttpDelete("EliminarItem/{usuarioId}/{productoId}")]
+        public async Task<IActionResult> EliminarItem(string usuarioId, string productoId)
+        {
+            await _carritoService.EliminarItemDelCarritoAsync(usuarioId, productoId);
+            return Ok();
+        }
 
-            [HttpDelete("EliminarItem/{usuarioId}/{productoId}")]
-            public async Task<IActionResult> EliminarItem(string usuarioId, string productoId)
-            {
-                await _carritoService.EliminarItemDelCarritoAsync(usuarioId, productoId);
-                return Ok();
-            }
-
-            [HttpDelete("VaciarCarrito/{usuarioId}")]
-            public async Task<IActionResult> VaciarCarrito(string usuarioId)
-            {
-                await _carritoService.VaciarCarritoAsync(usuarioId);
-                return Ok();
-            }
+        [HttpDelete("VaciarCarrito/{usuarioId}")]
+        public async Task<IActionResult> VaciarCarrito(string usuarioId)
+        {
+            await _carritoService.VaciarCarritoAsync(usuarioId);
+            return Ok();
         }
     }
+}
 

--- a/ProgressusWebApi/Controllers/MerchControllers/PagoController.cs
+++ b/ProgressusWebApi/Controllers/MerchControllers/PagoController.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using ProgressusWebApi.Dtos.MerchDtos;
+using ProgressusWebApi.Models.MerchModels;
+using ProgressusWebApi.Services.CarritoServices;
+using ProgressusWebApi.Services.PedidosServices.Interfaces;
+using WebApiMercadoPago.Services.Interface;
+
+namespace ProgressusWebApi.Controllers.MerchControllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PagoController : ControllerBase
+    {
+        private readonly IMercadoPagoService _mercadoPagoService;
+        private readonly IPedidoService _pedidoService;
+        private readonly ICarritoService _carritoService;
+        public PagoController(IMercadoPagoService mercadoPagoService, IPedidoService
+        pedidoService, ICarritoService carritoService)
+        {
+            _mercadoPagoService = mercadoPagoService;
+            _pedidoService = pedidoService;
+            _carritoService = carritoService;
+        }
+        [HttpPost("CrearPago/{usuarioId}")]
+        public async Task<IActionResult> CrearPago(string usuarioId, [FromBody] List<ItemCarritoDto>? items)
+        {
+            try
+            {
+                var pedido = await _pedidoService.RegistrarPedidoAsync(usuarioId, items);
+                if (pedido == null)
+                {
+                    return StatusCode(500, "No se encontró su pedido u ocurrió un error al buscarlo.");
+                }
+
+                var preferencia = await _mercadoPagoService.CrearPreferenciaDePagoCarritoAsync(pedido.Carrito, pedido.Id);
+                if (preferencia == null)
+                {
+                    return StatusCode(500, "Ocurrió un error al crear la preferencia de pago");
+                }
+
+                return Ok(new { Preference = preferencia, PedidoId = pedido.Id });
+            }
+            catch(Exception ex)
+            {
+                Console.WriteLine(ex.ToString());
+                return StatusCode(500, "Ocurrió un error al procesar el pedido.");
+            }
+            
+        }
+    }
+
+}

--- a/ProgressusWebApi/Controllers/NotificacionControllers/NotificacionesUsuarioController.cs
+++ b/ProgressusWebApi/Controllers/NotificacionControllers/NotificacionesUsuarioController.cs
@@ -57,7 +57,8 @@ namespace ProgressusWebApi.Controllers.NotificacionControllers
         }
 
 
-        
+        // Esta se usa para Descuentos y Promociones
+		// También para Motivacional
         [HttpPost ("CrearNotificacionMasiva")]        
         public async Task<IActionResult> CrearNotificacionMasiva([FromBody] NotificacionMasiva request)
         {

--- a/ProgressusWebApi/DbContext/ProgressusDataContext.cs
+++ b/ProgressusWebApi/DbContext/ProgressusDataContext.cs
@@ -247,15 +247,37 @@ namespace ProgressusWebApi.DataContext
                 .OnDelete(DeleteBehavior.Cascade);
 
 
-            // Configurar la clave primaria para CarritoItem
-            modelBuilder.Entity<CarritoItem>()
-                .HasKey(ci => ci.Id);
+            modelBuilder.Entity<Carrito>()
+                        .HasMany(c => c.Items)
+                        .WithOne(ci => ci.Carrito)
+                        .HasForeignKey(ci => ci.CarritoId)
+                        .OnDelete(DeleteBehavior.Cascade);
 
+
+            modelBuilder.Entity<CarritoItem>()
+                .HasOne(ci => ci.Merch)
+                .WithMany()  
+                .HasForeignKey(ci => ci.ProductoId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            
+            modelBuilder.Entity<Pedido>()
+                .HasOne(p => p.Carrito)
+                .WithOne()
+                .HasForeignKey<Pedido>(p => p.CarritoId)
+                .OnDelete(DeleteBehavior.Restrict);
 
             modelBuilder.Entity<Carrito>()
-      .HasMany(c => c.Items)
-      .WithOne()
-      .HasForeignKey(ci => ci.CarritoId); // Asegúrate de que CarritoItem tenga una propiedad CarritoId
+                .HasOne(c => c.Usuario) 
+                .WithMany()
+                .HasForeignKey(c => c.UsuarioId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<Pedido>()
+                .HasOne(c => c.Usuario) 
+                .WithMany()
+                .HasForeignKey(p => p.UsuarioId)
+                .OnDelete(DeleteBehavior.Restrict);
         }
     }
 }

--- a/ProgressusWebApi/Dtos/MercadoPagoDtos/NotificationDto.cs
+++ b/ProgressusWebApi/Dtos/MercadoPagoDtos/NotificationDto.cs
@@ -1,0 +1,21 @@
+﻿namespace ProgressusWebApi.Dtos.MercadoPagoDtos
+{
+    public class NotificationDto
+    {
+        // Pongo todos nulleables porque si alguno no llega se va a romper el serializador de c#
+        public int? id { get; set; }
+        public bool? live_mode { get; set; }
+        public string? type { get; set; }
+        public DateTime? date_created { get; set; }
+        public int? user_id { get; set; }
+        public string? api_version { get; set; }
+        public string? action { get; set; }
+        public Data? data { get; set; }
+    }
+
+    public class Data
+    {
+        public string? id { get; set; }
+    }
+
+}

--- a/ProgressusWebApi/Dtos/MerchDtos/ItemCarritoDto.cs
+++ b/ProgressusWebApi/Dtos/MerchDtos/ItemCarritoDto.cs
@@ -1,0 +1,10 @@
+﻿namespace ProgressusWebApi.Dtos.MerchDtos
+{
+    public class ItemCarritoDto
+    {
+        public int Id { get; set; }
+
+        public int Cantidad { get; set; }
+
+    }
+}

--- a/ProgressusWebApi/Models/MerchModels/Carrito.cs
+++ b/ProgressusWebApi/Models/MerchModels/Carrito.cs
@@ -1,4 +1,6 @@
-﻿namespace ProgressusWebApi.Models.MerchModels
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace ProgressusWebApi.Models.MerchModels
 {
     public class Carrito
     {
@@ -6,5 +8,7 @@
         public string UsuarioId { get; set; } // Relación con el usuario
         public List<CarritoItem> Items { get; set; } = new List<CarritoItem>(); // Relación con CarritoItem
         public decimal Total { get; set; } // Total del carrito
+
+        public IdentityUser Usuario { get; set; }
     }
 }

--- a/ProgressusWebApi/Models/MerchModels/CarritoItem.cs
+++ b/ProgressusWebApi/Models/MerchModels/CarritoItem.cs
@@ -3,12 +3,13 @@
     public class CarritoItem
     {
         public int Id { get; set; } // Clave primaria
-        public string ProductoId { get; set; } // Relación con el producto
-        public string Nombre { get; set; }
+        public int ProductoId { get; set; } // Relación con el producto}
         public int Cantidad { get; set; }
         public decimal PrecioUnitario { get; set; }
         public decimal Subtotal => Cantidad * PrecioUnitario; // Propiedad calculada
         public string CarritoId { get; set; } // Relación con el carrito
         public Carrito Carrito { get; set; } // Propiedad de navegación
+
+        public Merch Merch { get; set; }
     }
 }

--- a/ProgressusWebApi/Models/MerchModels/Pedido.cs
+++ b/ProgressusWebApi/Models/MerchModels/Pedido.cs
@@ -1,11 +1,19 @@
-﻿namespace ProgressusWebApi.Models.MerchModels
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace ProgressusWebApi.Models.MerchModels
 {
     public class Pedido
     {
         public string Id { get; set; }
         public string UsuarioId { get; set; }
-        public List<CarritoItem> Items { get; set; }
+        public string CarritoId { get; set; }
         public decimal Total { get; set; }
-        public string Estado { get; set; } // "Pendiente", "Pagado", "Cancelado"
+        public string Estado { get; set; }
+        public DateTime FechaCreacion { get; set; }
+
+        public DateTime FechaActualizacion { get; set; }
+
+        public Carrito Carrito { get; set; }
+        public IdentityUser Usuario { get; set; }
     }
 }

--- a/ProgressusWebApi/Program.cs
+++ b/ProgressusWebApi/Program.cs
@@ -39,6 +39,8 @@ using ProgressusWebApi.Repositories.NotificacionesRepositories.Interfaces;
 using ProgressusWebApi.Repositories.NotificacionesRepositories;
 using ProgressusWebApi.Services.AlimentoServices;
 using ProgressusWebApi.Services.CarritoServices;
+using ProgressusWebApi.Services.PedidosServices.Interfaces;
+using ProgressusWebApi.Services.PedidosServices;
 
 var builder = WebApplication.CreateBuilder(args);
 // Configuración de CORS para aceptar peticiones de cualquier origen
@@ -77,7 +79,7 @@ builder.Services.AddScoped<ISerieDeEjercicioRepository, SerieDeEjercicioReposito
 builder.Services.AddScoped<IObjetivoDelPlanService, ObjetivoDelPlanService>();
 builder.Services.AddScoped<IAsignacionDePlanRepository, AsignacionDePlanRepository>();
 builder.Services.AddScoped<IAsignacionDePlanService, AsignacionDePlanService>();
-
+builder.Services.AddScoped<IPedidoService, PedidoService>();
 builder.Services.AddScoped<IMembresiaRepository, MembresiaRepository>();
 builder.Services.AddScoped<IMembresiaService, MembresiaService>();
 builder.Services.AddScoped<ISolicitudDePagoRepository, SolicitudDePagoRepository>();

--- a/ProgressusWebApi/Repositories/MembresiaRepositories/Interfaces/IMercadoPagoRepository.cs
+++ b/ProgressusWebApi/Repositories/MembresiaRepositories/Interfaces/IMercadoPagoRepository.cs
@@ -2,12 +2,14 @@
 using MercadoPago.Config;
 using MercadoPago.Resource.Preference;
 using ProgressusWebApi.Models.MembresiaModels;
+using ProgressusWebApi.Models.MerchModels;
 
 namespace WebApiMercadoPago.Repositories.Interface
 {
     public interface IMercadoPagoRepository
     {
         Task<Preference> CreatePreferenceAsync(SolicitudDePago solicitud);
-       
+
+        Task<Preference> CrearPreferenciaDeCarritoAsync(Carrito carrito, string pedidoId);
     }
 }

--- a/ProgressusWebApi/Repositories/MembresiaRepositories/MercadoPagoRepository.cs
+++ b/ProgressusWebApi/Repositories/MembresiaRepositories/MercadoPagoRepository.cs
@@ -87,7 +87,8 @@ namespace WebApiMercadoPago.Repositories
                 Title = item.Merch?.Nombre, 
                 Quantity = item.Cantidad,
                 CurrencyId = "ARS",
-                UnitPrice = item.PrecioUnitario
+                UnitPrice = item.PrecioUnitario,
+                Description = item.Merch?.Nombre                
             }).ToList();
 
             var request = new PreferenceRequest
@@ -101,6 +102,7 @@ namespace WebApiMercadoPago.Repositories
                 },
                 NotificationUrl = "https://progressuscenter.azurewebsites.net/api/AAMercadoPago/NotificarPedidoCompletado/" + pedidoId ,
                 AutoReturn = "approved",
+                
                 Expires = true,
                 ExpirationDateFrom = DateTime.Now,
                 ExpirationDateTo = DateTime.Now.AddHours(1),

--- a/ProgressusWebApi/Repositories/MembresiaRepositories/MercadoPagoRepository.cs
+++ b/ProgressusWebApi/Repositories/MembresiaRepositories/MercadoPagoRepository.cs
@@ -6,6 +6,7 @@ using MercadoPago.Resource.Preference;
 using Microsoft.AspNetCore.Identity;
 using ProgressusWebApi.DataContext;
 using ProgressusWebApi.Models.MembresiaModels;
+using ProgressusWebApi.Models.MerchModels;
 using ProgressusWebApi.Services.AuthServices.Interfaces;
 using WebApiMercadoPago.Repositories.Interface;
 
@@ -21,7 +22,7 @@ namespace WebApiMercadoPago.Repositories
             _context = dataContext;
             _userManager = userManager;
 
-            
+
         }
 
         public async Task<Preference> CreatePreferenceAsync(SolicitudDePago solicitud)
@@ -49,7 +50,7 @@ namespace WebApiMercadoPago.Repositories
                     Name = usuario.UserName,
                     Email = usuario.Email,
                 },
-                
+
                 //Redirección del usuario según resultado del pago
                 BackUrls = new PreferenceBackUrlsRequest
                 {
@@ -77,5 +78,36 @@ namespace WebApiMercadoPago.Repositories
             Preference result = await client.CreateAsync(request);
             return result;
         }
+
+
+        public async Task<Preference> CrearPreferenciaDeCarritoAsync(Carrito carrito, string pedidoId)
+        {
+            var items = carrito.Items.Select(item => new PreferenceItemRequest
+            {
+                Title = item.Merch?.Nombre, 
+                Quantity = item.Cantidad,
+                CurrencyId = "ARS",
+                UnitPrice = item.PrecioUnitario
+            }).ToList();
+
+            var request = new PreferenceRequest
+            {
+                Items = items,
+                BackUrls = new PreferenceBackUrlsRequest
+                {
+                    Success = "https://pages-mp.vercel.app/success",
+                    Failure = "https://pages-mp.vercel.app/failure",
+                    Pending = "https://pages-mp.vercel.app/pending"
+                },
+                NotificationUrl = "https://progressuscenter.azurewebsites.net/api/AAMercadoPago/NotificarPedidoCompletado/" + pedidoId ,
+                AutoReturn = "approved",
+                Expires = true,
+                ExpirationDateFrom = DateTime.Now,
+                ExpirationDateTo = DateTime.Now.AddHours(1),
+            };
+            var client = new PreferenceClient();
+            return await client.CreateAsync(request);
+        }
+
     }
 }

--- a/ProgressusWebApi/Services/CarritoServices/CarritoService .cs
+++ b/ProgressusWebApi/Services/CarritoServices/CarritoService .cs
@@ -1,5 +1,6 @@
 ﻿using ProgressusWebApi.Models.MerchModels;
 using System.Collections.Concurrent;
+using WebApiMercadoPago.Repositories.Interface;
 
 namespace ProgressusWebApi.Services.CarritoServices
 {
@@ -36,8 +37,11 @@ namespace ProgressusWebApi.Services.CarritoServices
 
         public async Task EliminarItemDelCarritoAsync(string usuarioId, string productoId)
         {
+            if (!int.TryParse(productoId, out int proId))
+                return;
+
             var carrito = await ObtenerCarritoAsync(usuarioId);
-            var itemExistente = carrito.Items.FirstOrDefault(i => i.ProductoId == productoId);
+            var itemExistente = carrito.Items.FirstOrDefault(i => i.ProductoId == proId);
 
             if (itemExistente != null)
             {

--- a/ProgressusWebApi/Services/MembresiaServices/Interfaces/IMercadoPagoService.cs
+++ b/ProgressusWebApi/Services/MembresiaServices/Interfaces/IMercadoPagoService.cs
@@ -1,10 +1,15 @@
 ﻿using MercadoPago.Client.Preference;
 using MercadoPago.Resource.Preference;
+using ProgressusWebApi.Models.MerchModels;
 
 namespace WebApiMercadoPago.Services.Interface
 {
     public interface IMercadoPagoService
     {
         Task<Preference> CreatePreferenceAsync(PreferenceRequest preference);
+
+        Task<Preference> CrearPreferenciaDePagoCarritoAsync(Carrito carrito, string pedidoId);
+
+        Task<string> ConsultarEstadoPreferencia(string id);
     }
 }

--- a/ProgressusWebApi/Services/MembresiaServices/MercadoPagoService.cs
+++ b/ProgressusWebApi/Services/MembresiaServices/MercadoPagoService.cs
@@ -1,6 +1,12 @@
 ﻿using MercadoPago.Client.Preference;
+using MercadoPago.Resource.Payment;
 using MercadoPago.Resource.Preference;
+using Microsoft.AspNetCore.Identity;
+using ProgressusWebApi.Dtos.MercadoPagoDtos;
 using ProgressusWebApi.Models.MembresiaModels;
+using ProgressusWebApi.Models.MerchModels;
+using System.Net.Http;
+using System.Text.Json;
 using WebApiMercadoPago.Repositories.Interface;
 using WebApiMercadoPago.Services.Interface;
 
@@ -9,6 +15,7 @@ namespace WebApiMercadoPago.Services
     public class MercadoPagoService : IMercadoPagoService
     {
         private readonly IMercadoPagoRepository _mercadoPagoRepository;
+        private const string MercadoPagoBaseUrl = "https://api.mercadopago.com/v1/payments/";
 
         public MercadoPagoService(IMercadoPagoRepository mercadoPagoRepository)
         {
@@ -20,5 +27,39 @@ namespace WebApiMercadoPago.Services
             SolicitudDePago solicitud = new SolicitudDePago();
             return await _mercadoPagoRepository.CreatePreferenceAsync(solicitud);
         }
+
+        public async Task<Preference> CrearPreferenciaDePagoCarritoAsync(Carrito carrito, string pedidoId)
+        {
+            return await _mercadoPagoRepository.CrearPreferenciaDeCarritoAsync(carrito, pedidoId);
+        }
+
+        public async Task<string> ConsultarEstadoPreferencia(string id)
+        {
+            try
+            {
+                var httpClient = new HttpClient();
+
+                // Configurar la solicitud
+                var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, $"{MercadoPagoBaseUrl}{id}");
+                request.Headers.Add("Authorization", "Bearer APP_USR-2278733141716614-062815-583c9779901a7bbf32c8e8a73971e44c-1878150528");
+
+                // Realizar la solicitud
+                HttpResponseMessage response = await httpClient.SendAsync(request);
+                var res = response.Content.ReadAsStreamAsync().Result;
+                var data = JsonSerializer.Deserialize<PaymentDto>(res, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                return data.status;
+            }
+            catch
+            {
+                // la tiro porque ya está cacheada en el controller
+                throw;                
+            }
+
+        } 
+
     }
 }

--- a/ProgressusWebApi/Services/NotificacionesServices/NotificacionesUsuariosService.cs
+++ b/ProgressusWebApi/Services/NotificacionesServices/NotificacionesUsuariosService.cs
@@ -127,18 +127,20 @@ namespace ProgressusWebApi.Services.NotificacionesServices
                 }
             };
             var momentoDia = DateTime.Now.Hour <= 12 ? "Mañana" : "Tarde";
-            var pendiente = _estadoNotificacionRepository.ObtenerEstadosNotificacionesAsync().ContinueWith(n => n.Result.FirstOrDefault(p => p.Nombre == "Pendiente"))?.Result;
+            var estados = await _estadoNotificacionRepository.ObtenerEstadosNotificacionesAsync();
+            var pendiente = estados.FirstOrDefault(p => p.Nombre == "Pendiente");
             if (pendiente == null)
                 return false;
 
             var diaActual = mapeoDias.FirstOrDefault(d => d.Id == (int)DateTime.Now.DayOfWeek)?.Nombre;           
             var idNotificaciones = notificaciones
-                                    .Where(n => string.IsNullOrEmpty(n.PlantillaNotificacion.DiaSemana) || n.PlantillaNotificacion.DiaSemana?.ToLower() == diaActual.ToLower())
+                                    .Where(n => string.IsNullOrEmpty(n.PlantillaNotificacion.DiaSemana) || n.PlantillaNotificacion.DiaSemana?.ToLower() == diaActual?.ToLower())
                                     .Where(n => string.IsNullOrEmpty(n.PlantillaNotificacion.MomentoDia) || n.PlantillaNotificacion.MomentoDia == momentoDia)
                                     .Where(n => n.EstadoNotificacionId == pendiente.Id)
                                     .Select(n => n.Id)
                                     .ToList();
 
+            var enviada = estados.FirstOrDefault(p => p.Nombre == "Enviada");
             var ok = await _notificacionRepository.CambiarEstadoNotifiacionesMasivo(idNotificaciones, pendiente.Id);
 
             return ok;

--- a/ProgressusWebApi/Services/PedidosServices/Interfaces/IPedidoService.cs
+++ b/ProgressusWebApi/Services/PedidosServices/Interfaces/IPedidoService.cs
@@ -1,9 +1,12 @@
-﻿using ProgressusWebApi.Models.MerchModels;
+﻿using ProgressusWebApi.Dtos.MerchDtos;
+using ProgressusWebApi.Models.MerchModels;
 
 namespace ProgressusWebApi.Services.PedidosServices.Interfaces
 {
     public interface IPedidoService
     {
-        Task<Pedido> RegistrarPedidoAsync(string usuarioId, Carrito carrito);
+        Task<Pedido> RegistrarPedidoAsync(string usuarioId, List<ItemCarritoDto> carrito);
+
+        Task<bool> RegistrarPago(string pedidoId);
     }
 }

--- a/ProgressusWebApi/Services/PedidosServices/PedidoService.cs
+++ b/ProgressusWebApi/Services/PedidosServices/PedidoService.cs
@@ -65,9 +65,10 @@ namespace ProgressusWebApi.Services.PedidosServices
 
             _context.Carrito.Add(carrito);
 
+            var pedidoId = Guid.NewGuid().ToString();
             var pedido = new Pedido
             {
-                Id = Guid.NewGuid().ToString(),
+                Id = pedidoId,
                 UsuarioId = usuarioId,
                 CarritoId = carrito.Id,
                 FechaCreacion = DateTime.Now,
@@ -81,7 +82,9 @@ namespace ProgressusWebApi.Services.PedidosServices
 
             _context.SaveChanges();
 
-            return pedido;
+            // Lo busco nuevamente para tener disponible las descripciones del merch
+            var nuevo = _context.Pedido.Include(p => p.Carrito.Items).ThenInclude(p => p.Merch).FirstOrDefault(p => p.Id == pedidoId);
+            return nuevo;
         }
 
         public async Task<bool> RegistrarPago(string pedidoId)

--- a/ProgressusWebApi/Services/PedidosServices/PedidoService.cs
+++ b/ProgressusWebApi/Services/PedidosServices/PedidoService.cs
@@ -1,24 +1,107 @@
-﻿using ProgressusWebApi.Models.MerchModels;
+﻿using MercadoPago.Resource.Preference;
+using ProgressusWebApi.DataContext;
+using ProgressusWebApi.Dtos.MercadoPagoDtos;
+using ProgressusWebApi.Dtos.MerchDtos;
+using ProgressusWebApi.Models.MerchModels;
+using ProgressusWebApi.Services.PedidosServices.Interfaces;
+using WebApiMercadoPago.Services;
+using WebApiMercadoPago.Services.Interface;
+using Microsoft.EntityFrameworkCore;
 
 namespace ProgressusWebApi.Services.PedidosServices
 {
-    public class PedidoService
+    public class PedidoService : IPedidoService
     {
+        private readonly ProgressusDataContext _context;
         private static List<Pedido> _pedidos = new List<Pedido>();
 
-        public async Task<Pedido> RegistrarPedidoAsync(string usuarioId, Carrito carrito)
+        public PedidoService(ProgressusDataContext context)
         {
+            _context = context;
+        }
+        public async Task<Pedido> RegistrarPedidoAsync(string usuarioId, List<ItemCarritoDto> items)
+        {
+            if(items == null || items.Count == 0)
+                return null;
+
+            var itemIds = items.Select(p => p.Id).ToList();
+
+            var merchItems = _context.Merch.Where(m => itemIds.Contains(m.Id) && m.Stock > 0).ToList();
+
+            // Si falta algún merchitem o alguno no tiene stock
+            if (merchItems.Count != itemIds.Count)
+                return null;
+
+            var itemsCarrito = new List<CarritoItem>();
+
+            foreach (var item in items)
+            {
+                var merch = merchItems.FirstOrDefault(m => m.Id == item.Id);
+
+                if (merch == null || merch.Stock < item.Cantidad)
+                    return null;
+
+                itemsCarrito.Add(
+                    new CarritoItem()
+                    {
+                        ProductoId= item.Id,
+                        Cantidad = item.Cantidad,
+                        PrecioUnitario = merch.Precio,                        
+                    });
+            }
+
+            var carrito = new Carrito()
+            {
+                Id = Guid.NewGuid().ToString(),
+                Total = itemsCarrito.Sum(i => i.PrecioUnitario * i.Cantidad),
+                Items = itemsCarrito,
+                UsuarioId = usuarioId,    
+            };
+
+            _context.Carrito.Add(carrito);
+
             var pedido = new Pedido
             {
                 Id = Guid.NewGuid().ToString(),
                 UsuarioId = usuarioId,
-                Items = carrito.Items,
+                CarritoId = carrito.Id,
+                FechaCreacion = DateTime.Now,
+                FechaActualizacion = DateTime.Now,
+                Carrito = carrito,
                 Total = carrito.Total,
-                Estado = "Pendiente"
+                Estado = "Pendiente" // Acá debería ir a buscar el estado a algún lado pero el campo es un NVARCHAR de 100 :/ 
             };
 
-            _pedidos.Add(pedido);
+            _context.Pedido.Add(pedido);
+
+            _context.SaveChanges();
+
             return pedido;
+        }
+
+        public async Task<bool> RegistrarPago(string pedidoId)
+        {
+            try
+            {
+                var pedido = _context.Pedido.FirstOrDefault(p => p.Id == pedidoId);
+                if (pedido == null)
+                    return false;
+
+
+                pedido.Estado = "Pagado";
+                pedido.FechaActualizacion = DateTime.Now;
+                
+                _context.SaveChanges();
+
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+
+
         }
     }
 }


### PR DESCRIPTION

Se agregaron 2 servicios para cumplir con la funcionalidad:

**1 - POST /api/Pago/CrearPago/{usuarioId}**

Recibe un Id de usuario y un body con la lista de items del carrito a agregar.
Lo único que hace falta agregar de los items es el Id del merch y la cantidad que se lleva. 
El resto de info se calcula con lo existente en la base de datos.

Por lo que entiendo el Frontend no usa los métodos existentes CRUD de carrito (agregar item, vaciar, etc.), sino que lo tiene todo guardado en memoria hasta el momento de apretar el botón de pago. Por esta razón es que necesito obtener todos los items dentro del body.

Más allá de eso, el servicio se encarga de crear el objeto Pedido junto con su Carrito e Items y guardarlos dentro de la base de datos.

Después genera la preferencia de Pago de MP y la devuelve tal cual al front (acá podríamos hacer un DTO pero lo dejé como estaba el otro método de MP).
En la URL que se genera para MP se manda el Guid del pedido, que es lo que usamos después para atar el pago al pedido.

**2 - POST /api/AAMercadoPago/NotificarPedidoCompletado/{pedidoId}**

Recibe el Id de pedido únicamente. Verifica si llegó el id del pago y se consulta. Si quedó Approved, se actualiza el estado del pedido a "Pagado".  Si todo anduvo bien retorna Status Code 200.

Si no quedó en Approved, igual retorna Status Code 200 para que MP deje de llamarnos al endpoint.

Si algo falló, tira 400 Bad Request, para que MP reintente la llamada (por si hubo una intermitencia con la BD por ej.)