### PR TITLE
Mejoras en Notificacion de Membresia x vencer y Notificaciones quedan enviadas

### DIFF
--- a/ProgressusWebApi/Services/MembresiaServices/SolicitudDePagoService.cs
+++ b/ProgressusWebApi/Services/MembresiaServices/SolicitudDePagoService.cs
@@ -115,9 +115,11 @@ namespace ProgressusWebApi.Services.MembresiaServices
         public async Task<SolicitudDePago> ObtenerSolicitudDePagoDeSocio(string identityUserId)
         {
             SolicitudDePago solicitud = await _repository.ObtenerSolicitudDePagoDeSocio(identityUserId);
+            if(solicitud == null)
+                return null;
 
             var fechaVencimiento = solicitud.FechaCreacion.AddMonths(solicitud.Membresia.MesesDuracion);
-            if ( fechaVencimiento <= DateTime.Now.AddDays(-7))
+            if (fechaVencimiento > DateTime.Now && fechaVencimiento <= DateTime.Now.AddDays(-7))
             {
                 var planes = _membresiaRepository.GetAll().Result.Take(3).Select(m => $"{m.Nombre} -  ${m.Precio} : {m.Descripcion}").ToList();
                 await _notificacionesUsuarios.NotificarMembresiaPorVencer(identityUserId, fechaVencimiento.ToString("dd/MM/yyyy"), planes);                

--- a/ProgressusWebApi/Services/NotificacionesServices/NotificacionesUsuariosService.cs
+++ b/ProgressusWebApi/Services/NotificacionesServices/NotificacionesUsuariosService.cs
@@ -221,6 +221,18 @@ namespace ProgressusWebApi.Services.NotificacionesServices
                 cuerpo = cuerpo.Replace("[*for]", "");
                 cuerpo = cuerpo.Replace("[*end]", "");
 
+                
+                var notisUsuario = ObtenerNotificacionesPorUsuarioAsync(usuarioId)?.Result;
+                if(notisUsuario != null)
+                {
+                    var yaSeNotifico = notisUsuario.Where(n => n.Titulo == plantilla.Titulo)
+                                        .Where(n => n.FechaCreacion <= DateTime.Now.AddDays(-1))
+                                        .Any();
+                    if (yaSeNotifico)
+                        return true;
+
+                }
+
                 await GuardarNotificacion(usuarioId, plantilla, cuerpo);
 
 

--- a/ProgressusWebApi/Services/NotificacionesServices/NotificacionesUsuariosService.cs
+++ b/ProgressusWebApi/Services/NotificacionesServices/NotificacionesUsuariosService.cs
@@ -141,7 +141,7 @@ namespace ProgressusWebApi.Services.NotificacionesServices
                                     .ToList();
 
             var enviada = estados.FirstOrDefault(p => p.Nombre == "Enviada");
-            var ok = await _notificacionRepository.CambiarEstadoNotifiacionesMasivo(idNotificaciones, pendiente.Id);
+            var ok = await _notificacionRepository.CambiarEstadoNotifiacionesMasivo(idNotificaciones, enviada.Id);
 
             return ok;
         }


### PR DESCRIPTION
Ahora se valida que no se haya avisado durante el día sobre la membresía x vencer + ahora las notis quedan en estado enviada en lugar de pendiente